### PR TITLE
Add matrix clarifier to CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,6 +62,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the maintainers responsible for enforcement at:
 
 alexvonme at matrix dot org
+(This is not an email address, you may reach it after opening an account in matrix)
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
I added a small clarifier just in case people weren't accustomed to the matrix network.