### PR TITLE
ci: enable dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+---
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          # license identifiers come from https://spdx.org/licenses/
+          allow-licenses: >-
+            MIT,
+            CC-BY-4.0,
+            CC0-1.0,
+            Apache-2.0,
+            BSD-3-Clause,
+            BSD-3-Clause-Clear,
+            BSD-2-Clause


### PR DESCRIPTION
this GHA will make sure we are not importing things from licenses we don't want.                                                                                                                                                           
