### PR TITLE
Update .markdownlint.yaml to Remove Rule 41

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -6,3 +6,6 @@ default: true
 MD013:
   # Overload the default value (120)
   line_length: 200
+
+# Disable Rule: First line in a file should be a top-level heading
+MD041: false


### PR DESCRIPTION
I propose that we remove the rule that the "first line in a file should be a top-level heading". You can check the rule [here](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md).

This rule isn't useful since many files, especially those that aren't in the root directory, shouldn't start with a top level heading.