### PR TITLE
ci: enable typos via GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,7 @@ jobs:
 
       - name: Check for file names errors
         uses: ls-lint/action@v2.2.3
+
+      - name: typos-action
+        #  uses: crate-ci/typos@v1.21.0
+        uses: Shemnei/reviewdog-action-typos@v0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+[default]
+extend-ignore-identifiers-re = [
+    "ND", # CC-BY-ND, or ND-JSON
+]
+
+[files]
+extend-exclude = [
+    "**/*.good.txt",
+    "**/*.bad.txt"
+]

--- a/vale/styles/jargonLint/README.md
+++ b/vale/styles/jargonLint/README.md
@@ -8,7 +8,7 @@ These rules are intended for general use and are written to complement other sty
 
 ## Sources, Tools, and Methodology
 
-You may reach the detailed explaination and sources for each rule in their own folder inside the [sources](/sources) directory.
+You may reach the detailed explanation and sources for each rule in their own folder inside the [sources](/sources) directory.
 
 The folder for each rule:
 


### PR DESCRIPTION
Also, add its configuration files, and fix typos in README.md

Related to #15 
